### PR TITLE
feat: 아이디/닉네임 중복 확인, 비밀번호 확인, 회원 탈퇴 구현

### DIFF
--- a/src/main/java/com/example/eatpick/auth/controller/MemberController.java
+++ b/src/main/java/com/example/eatpick/auth/controller/MemberController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.eatpick.auth.domain.dto.request.MemberRequest;
@@ -17,7 +18,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@RestController("/member")
+@RestController
+@RequestMapping("/member")
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Member", description = "Member API")

--- a/src/main/java/com/example/eatpick/auth/controller/MemberController.java
+++ b/src/main/java/com/example/eatpick/auth/controller/MemberController.java
@@ -39,4 +39,28 @@ public class MemberController {
         SignInResponse response = memberService.signIn(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
+    @PostMapping("/check-loginId")
+    @Operation(description = "아이디 중복 확인")
+    public ResponseEntity<?> checkLoginId(@RequestBody String loginId) {
+        boolean isLoginIdDuplicate = memberService.checkLoginId(loginId);
+
+        if (isLoginIdDuplicate) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        } else {
+            return new ResponseEntity<>(HttpStatus.OK);
+        }
+    }
+
+    @PostMapping("/check-nickname")
+    @Operation(description = "닉네임 중복 확인")
+    public ResponseEntity<?> checkNickname(@RequestBody String nickname) {
+        boolean isNicknameDuplicate = memberService.checkNickname(nickname);
+
+        if (isNicknameDuplicate) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        } else {
+            return new ResponseEntity<>(HttpStatus.OK);
+        }
+    }
 }

--- a/src/main/java/com/example/eatpick/auth/controller/MemberController.java
+++ b/src/main/java/com/example/eatpick/auth/controller/MemberController.java
@@ -2,9 +2,11 @@ package com.example.eatpick.auth.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.eatpick.auth.domain.dto.request.MemberRequest;
@@ -33,6 +35,13 @@ public class MemberController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
+    @DeleteMapping("/withdraw")
+    @Operation(description = "회원탈퇴")
+    public ResponseEntity<MemberResponse> withdraw() {
+        memberService.withdraw();
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
     @PostMapping("/sign-in")
     @Operation(description = "로그인")
     public ResponseEntity<SignInResponse> signIn(@RequestBody SignInRequest request) {
@@ -42,7 +51,7 @@ public class MemberController {
 
     @PostMapping("/check-loginId")
     @Operation(description = "아이디 중복 확인")
-    public ResponseEntity<?> checkLoginId(@RequestBody String loginId) {
+    public ResponseEntity<?> checkLoginId(@RequestParam String loginId) {
         boolean isLoginIdDuplicate = memberService.checkLoginId(loginId);
 
         if (isLoginIdDuplicate) {
@@ -54,10 +63,22 @@ public class MemberController {
 
     @PostMapping("/check-nickname")
     @Operation(description = "닉네임 중복 확인")
-    public ResponseEntity<?> checkNickname(@RequestBody String nickname) {
+    public ResponseEntity<?> checkNickname(@RequestParam String nickname) {
         boolean isNicknameDuplicate = memberService.checkNickname(nickname);
 
         if (isNicknameDuplicate) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        } else {
+            return new ResponseEntity<>(HttpStatus.OK);
+        }
+    }
+
+    @PostMapping("/check-password")
+    @Operation(description = "비밀번호 확인")
+    public ResponseEntity<?> checkPassword(@RequestParam String loginPw, @RequestParam String verifiedLoginPw) {
+        boolean isPasswordCorrect = memberService.checkPassword(loginPw, verifiedLoginPw);
+
+        if (!isPasswordCorrect) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         } else {
             return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/java/com/example/eatpick/auth/controller/MyPageController.java
+++ b/src/main/java/com/example/eatpick/auth/controller/MyPageController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.eatpick.auth.domain.dto.request.MyPageUpdateRequest;
@@ -15,7 +16,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@RestController("/mypage")
+@RestController
+@RequestMapping("/mypage")
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Member", description = "Member API")

--- a/src/main/java/com/example/eatpick/auth/domain/dto/request/MyPageUpdateRequest.java
+++ b/src/main/java/com/example/eatpick/auth/domain/dto/request/MyPageUpdateRequest.java
@@ -3,7 +3,6 @@ package com.example.eatpick.auth.domain.dto.request;
 import com.example.eatpick.auth.domain.type.GenderType;
 
 public record MyPageUpdateRequest(
-    String loginId,
     String nickname,
     GenderType gender,
     int age

--- a/src/main/java/com/example/eatpick/auth/domain/dto/response/MyPageUpdateResponse.java
+++ b/src/main/java/com/example/eatpick/auth/domain/dto/response/MyPageUpdateResponse.java
@@ -4,13 +4,12 @@ import com.example.eatpick.auth.domain.entity.Member;
 import com.example.eatpick.auth.domain.type.GenderType;
 
 public record MyPageUpdateResponse(
-    String loginId,
     String nickname,
     GenderType gender,
     int age
 ) {
 
     public static MyPageUpdateResponse from(Member member) {
-        return new MyPageUpdateResponse(member.getLoginId(), member.getNickname(), member.getGender(), member.getAge());
+        return new MyPageUpdateResponse(member.getNickname(), member.getGender(), member.getAge());
     }
 }

--- a/src/main/java/com/example/eatpick/auth/repository/MemberRepository.java
+++ b/src/main/java/com/example/eatpick/auth/repository/MemberRepository.java
@@ -8,4 +8,8 @@ import com.example.eatpick.auth.domain.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByLoginId(String loginId);
+
+    boolean existsByLoginId(String loginId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/eatpick/auth/service/MemberService.java
+++ b/src/main/java/com/example/eatpick/auth/service/MemberService.java
@@ -19,6 +19,7 @@ import com.example.eatpick.auth.domain.entity.Member;
 import com.example.eatpick.auth.repository.MemberRepository;
 import com.example.eatpick.common.security.domain.dto.JwtToken;
 import com.example.eatpick.common.security.service.JwtTokenProvider;
+import com.example.eatpick.common.security.util.SecurityUtil;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +52,7 @@ public class MemberService {
     }
 
     public MyPageUpdateResponse myPageUpdate(MyPageUpdateRequest request) {
-        Member member = findByLoginId(request.loginId()).orElseThrow(
+        Member member = findByLoginId(SecurityUtil.getLoginId()).orElseThrow(
             () -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
 
         member.update(request);

--- a/src/main/java/com/example/eatpick/auth/service/MemberService.java
+++ b/src/main/java/com/example/eatpick/auth/service/MemberService.java
@@ -41,6 +41,13 @@ public class MemberService {
         return MemberResponse.from(member);
     }
 
+    public void withdraw() {
+        Member member = findByLoginId(SecurityUtil.getLoginId()).orElseThrow(
+            () -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
+
+        memberRepository.delete(member);
+    }
+
     public SignInResponse signIn(SignInRequest request) {
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
             request.loginId(), request.loginPw());
@@ -71,5 +78,9 @@ public class MemberService {
 
     public boolean checkNickname(String nickname) {
         return memberRepository.existsByNickname(nickname);
+    }
+
+    public boolean checkPassword(String loginPw, String verifiedLoginPw) {
+        return loginPw.equals(verifiedLoginPw);
     }
 }

--- a/src/main/java/com/example/eatpick/auth/service/MemberService.java
+++ b/src/main/java/com/example/eatpick/auth/service/MemberService.java
@@ -64,4 +64,12 @@ public class MemberService {
     public Optional<Member> findByLoginId(String loginId) {
         return memberRepository.findByLoginId(loginId);
     }
+
+    public boolean checkLoginId(String loginId) {
+        return memberRepository.existsByLoginId(loginId);
+    }
+
+    public boolean checkNickname(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
 }

--- a/src/main/java/com/example/eatpick/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/eatpick/common/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
             .httpBasic(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests((authorize) -> authorize
-                .requestMatchers("/**", "/sign-up", "/sign-in").permitAll()
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/member/sign-up", "/member/sign-in",
+                    "/member/check-loginId", "/member/check-nickname", "/member/check-password").permitAll()
                 .anyRequest().authenticated())
             .logout((logout) -> logout
                 .logoutSuccessUrl("/")


### PR DESCRIPTION
### 아이디/닉네임 중복 확인 API 응답 결과
![스크린샷 2024-12-24 오후 1 41 29](https://github.com/user-attachments/assets/56e1239e-a5c6-4a36-8db4-785337f011cb)

### 아이디/닉네임 중복 확인 API 응답 결과
![스크린샷 2024-12-24 오후 1 41 56](https://github.com/user-attachments/assets/a7ce0d2a-b763-4353-8c54-a8dd644221d3)

### 비밀번호 확인 API 응답 결과
![스크린샷 2024-12-24 오후 1 42 25](https://github.com/user-attachments/assets/a40f7b9f-3613-481c-ac30-831790115235)

### 회원 탈퇴 API 응답 결과
![스크린샷 2024-12-24 오후 1 44 54](https://github.com/user-attachments/assets/7444a8d6-682c-4fe1-83e8-d405fb1a51c8)
